### PR TITLE
Adding Windows host support + example

### DIFF
--- a/blueprints/azure-windows-blueprint.yaml
+++ b/blueprints/azure-windows-blueprint.yaml
@@ -1,0 +1,227 @@
+tosca_definitions_version: cloudify_dsl_1_2
+
+imports:
+  - http://www.getcloudify.org/spec/cloudify/3.3.1/types.yaml
+  - https://raw.githubusercontent.com/01000101/cloudify-azure-plugin/CFY-5107---Windows-host-support/plugin.yaml
+
+#####################################################################################
+# inputs section allows the user to use same
+# blueprint for creating different deployments, each one
+# with its own parameters.
+# to specify deployment inputs run:
+#   - cfy deployments create -b <blueprint_id> -d <deployment_id> -i inputs.json
+#####################################################################################
+
+inputs:
+  subscription_id:
+    type: string
+    default: ''
+
+  location:
+    type: string
+    default: 'West US'  
+
+  vm_prefix:
+    type: string
+    default: 'cfy'
+
+  vm_size: 
+    type: string
+    default: 'Standard_A2'
+  
+  image_reference_offer:
+    type: string
+    default: 'WindowsServer'
+    
+  image_reference_publisher:
+    type: string
+    default: 'MicrosoftWindowsServer'
+    
+  image_reference_sku:
+    type: string
+    default: '2012-R2-Datacenter'
+    
+  use_external_resource:
+    type: boolean
+    default: false
+
+  existing_resource_group_name:
+    type: string
+    default: ''
+    
+  existing_security_group_name:
+    type: string
+    default: ''
+
+  existing_storage_account_name:
+    type: string
+    default: ''
+
+  existing_vnet_name:
+    type: string
+    default: ''
+
+  subnet:
+    type: string
+    default: ''
+
+  existing_public_ip_name:
+    type: string
+    default: ''
+
+  existing_nic_name:
+    type: string
+    default: ''
+
+  client_id:
+    type: string
+    default: ''
+
+  tenant_id:
+    type: string
+    default: ''
+
+  username:
+    type: string
+    required: false
+  
+  password:
+    type: string
+    required: false
+  
+  aad_password:
+    type: string
+    default: ''
+    
+    
+node_types:
+  local.nodes.WindowsServer:
+    derived_from: cloudify.azure.nodes.WindowsServer
+    properties:
+      vm_prefix:
+        default: { get_input: vm_prefix }
+      username:
+        default: { get_input: username }
+      password:
+        default: { get_input: password }
+      image_reference_offer:
+        default: { get_input: image_reference_offer}
+      image_reference_publisher:
+        default: { get_input: image_reference_publisher}
+      image_reference_sku:
+        default: { get_input: image_reference_sku}
+      vm_size:
+        default: { get_input: vm_size}
+      subscription_id:
+        default: { get_input: subscription_id}
+      location:
+        default: { get_input: location }
+      client_id:
+        default: { get_input: client_id}
+      tenant_id:
+        default: { get_input: tenant_id}
+      aad_password:
+        default: { get_input: aad_password}
+    
+
+node_templates:
+
+  host:
+    type: local.nodes.WindowsServer
+    relationships:
+      - target: nic
+        type: cloudify.azure.relationships.server_connected_to_nic
+      - target: storage_account
+        type: cloudify.azure.relationships.server_connected_to_storage_account
+      - target: resource_group
+        type: cloudify.azure.relationships.resource_contained_in_resource_group
+
+  resource_group:
+    type: cloudify.azure.nodes.ResourceGroup
+    properties:
+      use_external_resource: true
+      existing_resource_group_name: { get_input: existing_resource_group_name}
+      
+    relationships:
+      - target: azure_token
+        type: cloudify.azure.relationships.resource_depends_on_azure_token
+     
+  storage_account:
+    type: cloudify.azure.nodes.StorageAccount
+    properties:
+      use_external_resource: true
+      existing_storage_account_name: { get_input: existing_storage_account_name}
+      
+    relationships:
+      - target: resource_group
+        type: cloudify.azure.relationships.storage_account_contained_in_resource_group
+
+
+  public_ip:
+    type: cloudify.azure.nodes.PublicIP
+    properties:
+      use_external_resource: { get_input: use_external_resource}
+      existing_public_ip_name: { get_input: existing_public_ip_name}
+      
+    relationships:
+      - target: vnet
+        type: cloudify.azure.relationships.public_ip_connected_to_vnet
+      - target: resource_group
+        type: cloudify.azure.relationships.resource_contained_in_resource_group
+
+  nic:
+    type: cloudify.azure.nodes.NIC
+    properties:
+      use_external_resource: { get_input: use_external_resource}
+      existing_nic_name: { get_input: existing_nic_name}
+      
+    relationships:
+      - target: public_ip
+        type: cloudify.azure.relationships.nic_connected_to_public_ip
+      - target: resource_group
+        type: cloudify.azure.relationships.resource_contained_in_resource_group
+
+  subnet:
+    type: cloudify.azure.nodes.Subnet
+    properties:
+      use_external_resource: true
+      subnet: { get_input: subnet}
+
+    relationships:
+      - target: resource_group
+        type: cloudify.azure.relationships.subnet_contained_in_resource_group
+
+
+  vnet:
+    type: cloudify.azure.nodes.VNET
+    properties:
+      use_external_resource: true
+      existing_vnet_name: { get_input: existing_vnet_name}
+
+    relationships:
+      - target: subnet
+        type: cloudify.azure.relationships.vnet_connected_to_subnet
+      - target: resource_group
+        type: cloudify.azure.relationships.vnet_contained_in_resource_group
+
+  azure_token:
+    type: cloudify.azure.nodes.azure_token
+    properties:
+      client_id: { get_input: client_id }
+      tenant_id: { get_input: tenant_id }
+      aad_password: { get_input: aad_password }
+      subscription_id: { get_input: subscription_id}
+      location: { get_input: location }
+
+  app:
+    type: cloudify.nodes.ApplicationModule
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: host
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        start:
+          implementation: scripts/powershell/echo.ps1
+          inputs:
+            process:
+              command_prefix: powershell

--- a/blueprints/inputs/azure.yaml
+++ b/blueprints/inputs/azure.yaml
@@ -13,11 +13,13 @@ existing_storage_account_name: ''
 existing_vnet_name: ''
 existing_nic_name: ''
 existing_public_ip_name: ''
-ssh_username: 'azuretest'
 aad_password: 'mypassword'
 custom_script_command: ''
 custom_script_path: ''
 data_disk_size_GB: ''
+
+# Linux options
+ssh_username: 'azuretest'
 key_data:  |
    ---- BEGIN SSH2 PUBLIC KEY ----
    Comment: "rsa-key-20150804"
@@ -28,3 +30,7 @@ key_data:  |
    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX   
    ---- END SSH2 PUBLIC KEY ----
+
+# Windows options
+username: cloudify
+password: Cloud1fyR0cks!

--- a/blueprints/scripts/powershell/echo.ps1
+++ b/blueprints/scripts/powershell/echo.ps1
@@ -1,0 +1,1 @@
+Write-Host "Hello, world!"

--- a/blueprints/scripts/winrm/enable_winrm_http.ps1
+++ b/blueprints/scripts/winrm/enable_winrm_http.ps1
@@ -1,0 +1,10 @@
+###########################################
+## Enables unencrypted WinRM HTTP access ##
+###########################################
+# http://docs.getcloudify.org/3.3.1/agents/overview/
+winrm quickconfig -q
+winrm set winrm/config '@{MaxTimeoutms="1800000"}'
+winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="300";MaxShellsPerUser="2147483647"}'
+winrm set winrm/config/service '@{AllowUnencrypted="true";MaxConcurrentOperationsPerUser="4294967295"}'
+winrm set winrm/config/service/auth '@{Basic="true"}'
+&netsh advfirewall firewall add rule name="WinRM 5985" protocol=TCP dir=in localport=5985 action=allow

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,7 +5,7 @@
 plugins:
   microsoft:
     executor: central_deployment_agent
-    source: https://github.com/cloudify-cosmo/cloudify-azure-plugin/archive/master.zip
+    source: https://github.com/01000101/cloudify-azure-plugin/archive/CFY-5107---Windows-host-support.zip
 
 node_types:
   cloudify.azure.nodes.ResourceGroup:
@@ -128,6 +128,81 @@ node_types:
       cloudify.interfaces.validation:
         creation:
           implementation: microsoft.azurecloudify.server.creation_validation
+
+
+  cloudify.azure.nodes.WindowsServer:
+    derived_from: cloudify.azure.nodes.Server
+    properties:
+      vm_prefix:
+        default: { get_input: vm_prefix }
+      install_agent:
+        default: true
+      subscription_id:
+        required: false
+      location:
+        required: false
+      client_id:
+        required: false
+      tenant_id:
+        required: false
+      vm_size:
+        description: >
+          Indicates the size of VM
+        type: string
+        default: 'Standard A1'
+      image_reference_offer:
+        description: >
+          Flavour of virtual machine
+        type: string
+        default: 'WindowsServer'
+      image_reference_publisher:
+        description: >
+          Publisher of virtual machine
+        type: string
+        default: 'MicrosoftWindowsServer'
+      image_reference_sku:
+        description: >
+          Version of operating system
+        type: string
+        default: '2012-R2-Datacenter'       
+      username:
+        type: string
+        description: >
+          Administrator username to set on the instance
+        default: cloudify
+      password:
+        type: string
+        description: >
+          Administrator password to set on the instance
+        default: Cloud1fyR0cks!
+      os_family:
+        type: string
+        description: >
+          Property specifying what type of operating system family
+          this compute node will run. Valid choices are
+          "windows" and "linux"
+        default: windows
+      vmx_script_urls:
+        description: >
+          A list of URLs to pass as Virtual Machine Extension
+          scripts. Use the vmx_script_entry property to specify
+          which script will act as the execution entry point
+        default:
+        - https://raw.githubusercontent.com/01000101/cloudify-azure-plugin/CFY-5107---Windows-host-support/blueprints/scripts/winrm/enable_winrm_http.ps1
+      vmx_script_entry:
+        type: string
+        description: >
+          The filename to execute. For instance, if a VMX script URL
+          is http://some-domain.com/scripts/my_script.ps1, this property
+          should be my_script.ps1
+        default: enable_winrm_http.ps1
+      agent_config:
+        type: cloudify.datatypes.AgentConfig
+        default:
+          install_method: remote
+          port: 5985
+          user: { get_property: [SELF, username] }
+          password: { get_property: [SELF, password] }
 
 
   cloudify.azure.nodes.ServerWithNic:


### PR DESCRIPTION
Added a new Windows node_type for use.  This didn't work with Diamond monitoring so I built a separate blueprint as an example use (very very basic).  I'm sure this would work fine with Nodecellar or whatever else for an example but primary goal was getting Windows support, not writing clever examples. :laughing:  

The way it works is that there is a post-deployment "extension" script that actually enables WinRM HTTP unencrypted properly and which allows the agent to connect.  The limitation of this is that no further extension scripts can be used with Windows hosts (probably not a big deal).  The only way around this issue is if Cloudify started supporting Kerberos or key auth for WinRM. 

_This will probably NOT work with versions of Windows Server prior to 2012 from what I can see.  I tested with 2008 and there's a known issue with their extension script support where it will not allow scripts to be run as super user (which is needed for WinRM operations).  _

Windows node_type updates

Adding debugging

D'oh again

D'oh

Bad URL

Fixing Windows hosts