### PR TITLE
Multiple NIC support, FortiGate example

### DIFF
--- a/cloudify_azure/utils.py
+++ b/cloudify_azure/utils.py
@@ -574,14 +574,15 @@ def get_subscription_id(_ctx=ctx):
 
 
 def secure_logging_content(content, secure_keywords=constants.SECURE_KW):
-
+    '''Scrubs logging calls containing potentially sensitive information'''
     def clean(clean_me, secure_keywords=secure_keywords):
-        if type(clean_me) is list:
-            for li in clean_me:
-                clean_me[clean_me.index(li)] = clean(li)
-        elif type(clean_me) is dict:
+        '''Srubs potentially sensitive data from a list or dict'''
+        if isinstance(clean_me, list):
+            for obj in clean_me:
+                clean_me[clean_me.index(obj)] = clean(obj)
+        elif isinstance(clean_me, dict):
             for key, value in clean_me.items():
-                if type(key) is str and key in secure_keywords:
+                if isinstance(key, str) and key in secure_keywords:
                     clean_me[key] = '*'
                 else:
                     clean(value)

--- a/examples/fortigate/blueprint.yaml
+++ b/examples/fortigate/blueprint.yaml
@@ -1,0 +1,292 @@
+tosca_definitions_version: cloudify_dsl_1_2
+
+description: >
+  This blueprint creates a Fortinet FortiGate appliance that
+  sits between two networks (public and private) and has a
+  public IP associated with it for port TCP/443 (HTTPS) access.
+
+imports:
+- http://www.getcloudify.org/spec/cloudify/3.3.1/types.yaml
+- https://raw.githubusercontent.com/cloudify-cosmo/cloudify-azure-plugin/master/plugin.yaml
+
+
+inputs:
+  resource_prefix:
+    default: forti
+  resource_suffix:
+    default: 1
+  # Azure account information
+  subscription_id:
+    type: string
+    required: true
+  tenant_id:
+    type: string
+    required: true
+  client_id:
+    type: string
+    required: true
+  client_secret:
+    type: string
+    required: true
+  location:
+    type: string
+    required: true
+    default: eastus
+  retry_after:
+    type: integer
+    default: 45
+  # Virtual Machine information
+  vm_size: 
+    type: string
+    required: true
+    default: Standard_D3
+  vm_os_family:
+    type: string
+    required: true
+    default: linux
+  vm_image_publisher: 
+    type: string
+    required: true
+    default: fortinet
+  vm_image_offer: 
+    type: string
+    required: true
+    default: fortinet_fortigate-vm_v5
+  vm_image_sku:
+    type: string
+    required: true
+    default: fortinet_fg-vm
+  vm_image_version:
+    type: string
+    required: true
+    default: latest
+  vm_os_username:
+    description: >
+      Username to create as the VM's administrator user
+    type: string
+    required: true
+    default: cloudify
+  vm_os_password:
+    description: >
+      Password to use for the VM's administrator user
+    type: string
+    required: true
+    default: Cl0ud1fy!
+  # Networking info
+  vnet_cidr_block:
+    type: string
+    default: 10.1.0.0/23
+  subnet_public_cidr_block:
+    type: string
+    default: 10.1.0.0/24
+  subnet_private_cidr_block:
+    type: string
+    default: 10.1.1.0/24
+
+
+dsl_definitions:
+  azure_configuration: &azure_configuration
+    subscription_id: { get_input: subscription_id }
+    tenant_id: { get_input: tenant_id }
+    client_id: { get_input: client_id }
+    client_secret: { get_input: client_secret }
+
+
+node_templates:
+  resource_group:
+    type: cloudify.azure.nodes.ResourceGroup
+    properties:
+      name: {concat:[{get_input: resource_prefix},rg,{get_input: resource_suffix}]}
+      location: { get_input: location }
+      azure_config: *azure_configuration
+      
+  storage_account:
+    type: cloudify.azure.nodes.storage.StorageAccount
+    properties:
+      name: {concat:[{get_input: resource_prefix},sa,{get_input: resource_suffix}]}
+      location: { get_input: location }
+      retry_after: { get_input: retry_after }
+      azure_config: *azure_configuration
+      resource_config:
+        accountType: Standard_LRS
+    relationships:
+    - type: cloudify.azure.relationships.contained_in_resource_group
+      target: resource_group
+  
+  availability_set:
+    type: cloudify.azure.nodes.compute.AvailabilitySet
+    properties:
+      name: {concat:[{get_input: resource_prefix},availset,{get_input: resource_suffix}]}
+      location: { get_input: location }
+      retry_after: { get_input: retry_after }
+      azure_config: *azure_configuration
+    relationships:
+    - type: cloudify.azure.relationships.contained_in_resource_group
+      target: resource_group
+  
+  virtual_network:
+    type: cloudify.azure.nodes.network.VirtualNetwork
+    properties:
+      name: {concat:[{get_input: resource_prefix},vnet,{get_input: resource_suffix}]}
+      location: { get_input: location }
+      retry_after: { get_input: retry_after }
+      azure_config: *azure_configuration
+      resource_config:
+        addressSpace:
+          addressPrefixes:
+          - { get_input: vnet_cidr_block }
+    relationships:
+    - type: cloudify.azure.relationships.contained_in_resource_group
+      target: resource_group
+  
+  ######################
+  # Public subnet, NIC #
+  ######################
+  subnet_public:
+    type: cloudify.azure.nodes.network.Subnet
+    properties:
+      name: {concat:[{get_input: resource_prefix},subnetPub,{get_input: resource_suffix}]}
+      resource_group_name: { get_property: [resource_group, name] }
+      location: { get_input: location }
+      azure_config: *azure_configuration
+      resource_config:
+        addressPrefix: { get_input: subnet_public_cidr_block }
+    relationships:
+    - type: cloudify.azure.relationships.contained_in_virtual_network
+      target: virtual_network
+
+  public_ip:
+    type: cloudify.azure.nodes.network.PublicIPAddress
+    properties:
+      name: {concat:[{get_input: resource_prefix},pip,{get_input: resource_suffix}]}
+      location: { get_input: location }
+      retry_after: { get_input: retry_after }
+      azure_config: *azure_configuration
+      resource_config:
+        publicIPAllocationMethod: Static
+    relationships:
+    - type: cloudify.azure.relationships.contained_in_resource_group
+      target: resource_group
+     
+  nic_public_ip_config:
+    type: cloudify.azure.nodes.network.IPConfiguration
+    properties:
+      name: {concat:[{get_input: resource_prefix},nicipPub,{get_input: resource_suffix}]}
+      location: { get_input: location }
+      retry_after: { get_input: retry_after }
+      azure_config: *azure_configuration
+      resource_config:
+        privateIPAllocationMethod: Dynamic
+    relationships:
+    - type: cloudify.azure.relationships.ip_configuration_connected_to_subnet
+      target: subnet_public
+    - type: cloudify.azure.relationships.ip_configuration_connected_to_public_ip
+      target: public_ip
+   
+  nic_public:
+    type: cloudify.azure.nodes.network.NetworkInterfaceCard
+    properties:
+      name: {concat:[{get_input: resource_prefix},nicPub,{get_input: resource_suffix}]}
+      location: { get_input: location }
+      retry_after: { get_input: retry_after }
+      primary: true
+      azure_config: *azure_configuration
+    relationships:
+    - type: cloudify.azure.relationships.contained_in_resource_group
+      target: resource_group
+    - type: cloudify.azure.relationships.connected_to_ip_configuration
+      target: nic_public_ip_config
+
+  #######################
+  # Private subnet, NIC #
+  #######################
+  subnet_private:
+    type: cloudify.azure.nodes.network.Subnet
+    properties:
+      name: {concat:[{get_input: resource_prefix},subnetPriv,{get_input: resource_suffix}]}
+      resource_group_name: { get_property: [resource_group, name] }
+      location: { get_input: location }
+      azure_config: *azure_configuration
+      resource_config:
+        addressPrefix: { get_input: subnet_private_cidr_block }
+    relationships:
+    - type: cloudify.azure.relationships.contained_in_virtual_network
+      target: virtual_network
+    - type: cloudify.relationships.depends_on
+      target: subnet_public
+      
+  nic_private_ip_config:
+    type: cloudify.azure.nodes.network.IPConfiguration
+    properties:
+      name: {concat:[{get_input: resource_prefix},nicipPriv,{get_input: resource_suffix}]}
+      location: { get_input: location }
+      retry_after: { get_input: retry_after }
+      azure_config: *azure_configuration
+      resource_config:
+        privateIPAllocationMethod: Dynamic
+    relationships:
+    - type: cloudify.azure.relationships.ip_configuration_connected_to_subnet
+      target: subnet_private
+   
+  nic_private:
+    type: cloudify.azure.nodes.network.NetworkInterfaceCard
+    properties:
+      name: {concat:[{get_input: resource_prefix},nicPriv,{get_input: resource_suffix}]}
+      location: { get_input: location }
+      retry_after: { get_input: retry_after }
+      primary: false
+      azure_config: *azure_configuration
+    relationships:
+    - type: cloudify.azure.relationships.contained_in_resource_group
+      target: resource_group
+    - type: cloudify.azure.relationships.connected_to_ip_configuration
+      target: nic_private_ip_config
+      
+  ############################
+  # Fortinet FortiGate NG-FW #
+  ############################
+  fortigate_vm:
+    type: cloudify.azure.nodes.compute.VirtualMachine
+    properties:
+      name: {concat:[{get_input: resource_prefix},vm,{get_input: resource_suffix}]}
+      location: { get_input: location }
+      retry_after: { get_input: retry_after }
+      os_family: { get_input: vm_os_family }
+      azure_config: *azure_configuration
+      plan:
+        name: { get_input: vm_image_sku }
+        publisher: { get_input: vm_image_publisher }
+        product: { get_input: vm_image_offer }
+      resource_config:
+        hardwareProfile:
+          vmSize: { get_input: vm_size }
+        storageProfile:
+          imageReference:
+            publisher: { get_input: vm_image_publisher }
+            offer: { get_input: vm_image_offer }
+            sku: { get_input: vm_image_sku }
+            version: { get_input: vm_image_version }
+        osProfile:
+          computerName: { get_property: [SELF, name] }
+          adminUsername: { get_input: vm_os_username }
+          adminPassword: { get_input: vm_os_password }
+      agent_config:
+        install_method: none
+    relationships:
+    - type: cloudify.azure.relationships.contained_in_resource_group
+      target: resource_group
+    - type: cloudify.azure.relationships.connected_to_storage_account
+      target: storage_account
+    - type: cloudify.azure.relationships.connected_to_availability_set
+      target: availability_set
+    - type: cloudify.azure.relationships.connected_to_nic
+      target: nic_public
+    - type: cloudify.azure.relationships.connected_to_nic
+      target: nic_private
+
+
+outputs:
+  fortigate_vm_public_ip:
+    value: { get_attribute: [ fortigate_vm, public_ip ] }
+  fortigate_vm_private_ip:
+    value: { get_attribute: [ fortigate_vm, ip ] }

--- a/examples/fortigate/inputs.yaml
+++ b/examples/fortigate/inputs.yaml
@@ -1,0 +1,26 @@
+# Account info
+subscription_id: AZURE_SUBSCRIPTION_ID
+tenant_id: AZURE_TENANT_ID
+client_id: AZURE_CLIENT_ID
+client_secret: AZURE_CLIENT_SECRET
+location: westeurope
+
+# General
+retry_after: 30
+
+# Networking
+vnet_cidr_block: 10.1.0.0/23
+subnet_public_cidr_block: 10.1.0.0/24
+subnet_private_cidr_block: 10.1.1.0/24
+
+# FortiGate VM
+vm_size: Standard_D3
+vm_os_family: linux
+vm_image_publisher: fortinet
+vm_image_offer: fortinet_fortigate-vm_v5
+vm_image_sku: fortinet_fg-vm
+vm_image_version: latest
+
+# Access
+vm_os_username: cloudify
+vm_os_password: Cl0ud1fy!

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -152,8 +152,7 @@ data_types:
       ipConfigurations:
         required: false
       dnsSettings:
-        required: false
-        
+        required: false      
   
   cloudify.datatypes.azure.network.IPConfigurationConfig:
     properties:
@@ -776,6 +775,11 @@ node_types:
         description: >
           Specifies a dictionary of one or more name and value pairs that describe a tag
         required: false
+      primary:
+        description: >
+          When using multiple Network Interfaces, a primary must be set
+        required: false
+        default: false
       resource_config:
         description: >
           A dictionary of values to pass as properties when creating the resource
@@ -985,6 +989,11 @@ node_types:
       tags:
         description: >
           Specifies a dictionary of one or more name and value pairs that describe a tag
+        required: false
+      plan:
+        description: >
+          Specifies information about the marketplace image used to create the virtual
+          machine. This element is only used for marketplace images.
         required: false
       resource_config:
         description: >
@@ -1435,4 +1444,3 @@ relationships:
       cloudify.interfaces.relationship_lifecycle:
         establish: pkg.cloudify_azure.resources.network.loadbalancer.attach_nic_to_backend_pool
         unlink: pkg.cloudify_azure.resources.network.loadbalancer.detach_nic_from_backend_pool
-        

--- a/system_tests/local/azure_tests.py
+++ b/system_tests/local/azure_tests.py
@@ -108,7 +108,7 @@ class AzureSystemTests(TestCase):
 
         self.localenv.execute('install', task_retries=40)
         self.post_install_assertions()
-        self.localenv.execute('uninstall', task_retries=5)
+        self.localenv.execute('uninstall', task_retries=40)
         self.post_uninstall_assertions()
 
     @property


### PR DESCRIPTION
Multiple NIC support is added with the "Primary" property added to the NetworkInterfaceCard type.

Added support for Azure Marketplace images (those requiring additional licensing / expense) by adding the "Plan" property to the VirtualMachine type. 

Fortinet FortiGate VNF example BP added which behaves like the ones for VMware & OpenStack (which utilizes the multi-NIC and Azure Marketplace features)
