### PR TITLE
VM name generator fix

### DIFF
--- a/cloudify_azure/resources/compute/virtualmachine.py
+++ b/cloudify_azure/resources/compute/virtualmachine.py
@@ -177,9 +177,14 @@ def build_network_profile():
 
 def vm_name_generator():
     '''Generates a unique VM resource name'''
-    return ''.join(random.choice(
+    name = ''.join(random.choice(
         string.lowercase + string.digits + '-'
     ) for i in range(random.randint(10, 64)))
+    if name.endswith('-'):
+        name[-1] = random.choice(string.lowercase + string.digits)
+    if name.startswith('-'):
+        name[0] = random.choice(string.lowercase + string.digits)
+    return name
 
 
 @operation

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,7 +5,7 @@
 plugins:
   pkg:
     executor: central_deployment_agent
-    source: https://github.com/cloudify-cosmo/cloudify-azure-plugin/archive/1.4.1.zip
+    source: https://github.com/01000101/cloudify-azure-plugin/archive/vm-name-gen-fix.zip
     package_name: cloudify-azure-plugin
     package_version: '1.4.1'
 


### PR DESCRIPTION
Azure validation says that a name cannot end with a dash. I couldn't use their validation rule for checking other cases, so I also removed the possibility of dashes at the start of the name too. 