### PR TITLE
VM name generator fix

### DIFF
--- a/cloudify_azure/resources/base.py
+++ b/cloudify_azure/resources/base.py
@@ -393,9 +393,12 @@ class Resource(object):
         # HTTP 200 (OK) - The resource already exists
         elif res.status_code == httplib.OK:
             return True
-        # If Azure sent a 404, the resource doesn't exist (yet?)
-        if res.status_code == httplib.NOT_FOUND:
+        # HTTP 404 (NOT_FOUND) - The resource can't be found
+        elif res.status_code == httplib.NOT_FOUND:
             return False
+        # HTTP 400 (BAD_REQUEST) - The resource name is invalid
+        elif res.status_code == httplib.BAD_REQUEST:
+            raise ValueError('Invalid resource name')
         raise UnexpectedResponse(
             'Recieved unexpected HTTP ({0}) response'
             .format(res.status_code), res.json())

--- a/cloudify_azure/resources/compute/virtualmachine.py
+++ b/cloudify_azure/resources/compute/virtualmachine.py
@@ -21,8 +21,7 @@
 # Deep object copying
 from copy import deepcopy
 # Random string
-import random
-import string
+from uuid import uuid4
 # Node properties and logger
 from cloudify import ctx
 # Exception handling
@@ -177,9 +176,7 @@ def build_network_profile():
 
 def vm_name_generator():
     '''Generates a unique VM resource name'''
-    return ''.join(random.choice(
-        string.lowercase + string.digits + '-'
-    ) for i in range(random.randint(10, 64)))
+    return uuid4()
 
 
 @operation

--- a/cloudify_azure/resources/compute/virtualmachine.py
+++ b/cloudify_azure/resources/compute/virtualmachine.py
@@ -176,7 +176,7 @@ def build_network_profile():
 
 def vm_name_generator():
     '''Generates a unique VM resource name'''
-    return uuid4()
+    return str(uuid4())
 
 
 @operation

--- a/cloudify_azure/utils.py
+++ b/cloudify_azure/utils.py
@@ -112,14 +112,18 @@ def generate_resource_name(resource, generator=None, name=None, _ctx=ctx):
     name = name or get_resource_name(_ctx)
     # Generate a new name (if needed)
     if not name:
-        for _ in xrange(0, 10):
+        for _ in xrange(0, 15):
             if generator:
                 name = generator()
             else:
                 name = str(uuid4())
             # Check if we have a duplicate name
-            if not resource.exists(name):
-                break
+            try:
+                if not resource.exists(name):
+                    break
+            except ValueError:
+                # Catch an HTTP 400 response for invalid name
+                pass
     # Set the new name in the runtime properties
     _ctx.instance.runtime_properties['name'] = name
     return name

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,7 +5,7 @@
 plugins:
   pkg:
     executor: central_deployment_agent
-    source: https://github.com/cloudify-cosmo/cloudify-azure-plugin/archive/1.4.1.zip
+    source: https://github.com/01000101/cloudify-azure-plugin/archive/rf-updates.zip
     package_name: cloudify-azure-plugin
     package_version: '1.4.1'
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,7 +5,7 @@
 plugins:
   pkg:
     executor: central_deployment_agent
-    source: https://github.com/01000101/cloudify-azure-plugin/archive/rf-updates.zip
+    source: https://github.com/cloudify-cosmo/cloudify-azure-plugin/archive/master.zip
     package_name: cloudify-azure-plugin
     package_version: '1.4.1'
 


### PR DESCRIPTION
We discovered a bug in the VM name generator that caused invalid names to be allowed. This is now changed to use UUIDv4 and also catch invalid names (HTTP 400 responses during checks) and retry. 