### PR TITLE
RD-278-Fix-Public-IPs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+3.0.7: Handle Public IPs.
 3.0.6: Handle regression in network profile.
 3.0.5: Fix Build Error.
 3.0.4: Handle regression error in ipconfiguration.

--- a/cloudify_azure/resources/compute/virtualmachine.py
+++ b/cloudify_azure/resources/compute/virtualmachine.py
@@ -448,7 +448,8 @@ def configure(ctx, command_to_execute, file_uris, type_handler_version='1.8',
                     public_ip_data = pip.get(resource_group_name, pip_name)
                     public_ip = public_ip_data.get("ip_address")
             if not public_ip:
-                public_ip = ctx.instance.runtime_properties['ip']
+                # skip the public ip from this ip configuration as it is None
+                continue
 
             ctx.instance.runtime_properties['public_ip'] = public_ip
             # For consistency with other plugins.

--- a/cloudify_azure/utils.py
+++ b/cloudify_azure/utils.py
@@ -331,6 +331,9 @@ def cleanup_empty_params(data):
     """
 
     def convert_key_val(key):
+        # handle special case where -IP- inside the key
+        if 'IP' in key:
+            key = key.replace('IP', 'Ip')
         new_key = key[0].lower()
         for character in key[1:]:
             # Append an underscore if the character is uppercase.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,9 +5,9 @@
 plugins:
   azure:
     executor: central_deployment_agent
-    source: https://github.com/cloudify-cosmo/cloudify-azure-plugin/archive/3.0.6.zip
+    source: https://github.com/cloudify-cosmo/cloudify-azure-plugin/archive/3.0.7.zip
     package_name: cloudify-azure-plugin
-    package_version: '3.0.6'
+    package_version: '3.0.7'
 
 data_types:
   cloudify.datatypes.azure.Config:


### PR DESCRIPTION
Handle Special Case of IP inside the key when mapping rest key to sdk python version for example : 
(privateIPAllocationMethod) , and skip using the private IP instead of public IP addresses in case the IP configuration doesn't have the public IP