### PR TITLE
Azure VM as idempotent

### DIFF
--- a/cloudify_azure/decorators.py
+++ b/cloudify_azure/decorators.py
@@ -220,13 +220,12 @@ def with_azure_resource(resource_class_name):
             # to other idempotent deployments.
             arm_deployment = 'cloudify.azure.Deployment' in \
                              ctx.node.type_hierarchy
+            azure_vm = 'cloudify.azure.nodes.compute.VirtualMachine' in \
+                       ctx.node.type_hierarchy
+            idempotent_deployment = arm_deployment or azure_vm
             create_op = 'create' in ctx.operation.name.split('.')[-1]
 
-            if not exists and expected and not create_anyway:
-                raise cfy_exc.NonRecoverableError(
-                    "Can't use non-existing {0} '{1}'.".format(
-                        resource_class_name, name))
-            elif use_existing and not (create_op and arm_deployment):
+            if use_existing and not (create_op and idempotent_deployment):
                 ctx.logger.info("Using external resource")
                 ctx.instance.runtime_properties['resource'] = exists
                 ctx.instance.runtime_properties['resource_id'] = exists.get(


### PR DESCRIPTION
Azure VM execute_operation fix.


Parameters of execute_operation run:
```
{
   "operation":"cloudify.interfaces.lifecycle.create",
   "operation_kwargs":{
      "args":{
         "hardwareProfile":{
            "vmSize":"Standard_A2_v2"
         }
      }
   },
   "allow_kwargs_override":true,
   "run_by_dependency_order":false,
   "type_names":[

   ],
   "node_ids":[
      "vm"
   ],
   "node_instance_ids":[

   ]
}
```