### PR TITLE
Rd 626 support create if missing compute resources

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+3.3.0: Add create_if_missing for all azure resources.
 3.2.1: Fix bug, fail if trying to use external resource that doesn't exist.
 3.2.0: Add pull operation for Azure ARM deployment.
 3.1.0: Support create if missing/use if exists logic.

--- a/cloudify_azure/decorators.py
+++ b/cloudify_azure/decorators.py
@@ -241,9 +241,8 @@ def with_azure_resource(resource_class_name):
             elif not create and not (create_op and arm_deployment):
                 raise cfy_exc.NonRecoverableError(
                     "Can't use non-existing,"
-                    " or resource alredy exist but configartion is not to use "
-                    "it:  {0} '{1}'.".format(
-                        resource_class_name, name))
+                    " or resource already exist but configuration is not to"
+                    " use it:  {0} '{1}'.".format(resource_class_name, name))
             elif create and exists and ctx.workflow_id not in \
                     ['update', 'execute_operation']:
                 ctx.logger.warn("Resource with name {0} exists".format(name))

--- a/cloudify_azure/resources/compute/managed_cluster.py
+++ b/cloudify_azure/resources/compute/managed_cluster.py
@@ -25,56 +25,6 @@ from cloudify_azure import (constants, utils, decorators)
 from azure_sdk.resources.compute.managed_cluster import ManagedCluster
 
 
-# @operation(resumable=True)
-# def create(ctx, resource_group, cluster_name, resource_config, **kwargs):
-#     azure_config = utils.get_client_config(ctx.node.properties)
-#     store_kube_config_in_runtime = \
-#         ctx.node.properties.get('store_kube_config_in_runtime')
-#     api_version = \
-#         ctx.node.properties.get('api_version',
-#                                 constants.API_VER_MANAGED_CLUSTER)
-#     managed_cluster = ManagedCluster(azure_config, ctx.logger, api_version)
-#     resource_config_payload = {}
-#     resource_config_payload = \
-#         utils.handle_resource_config_params(resource_config_payload,
-#                                             resource_config)
-#     try:
-#         result = managed_cluster.get(resource_group, cluster_name)
-#         if ctx.node.properties.get('use_external_resource', False):
-#             ctx.logger.info("Using external resource")
-#         else:
-#             ctx.logger.info("Resource with name {0} exists".format(
-#                 cluster_name))
-#             return
-#     except CloudError:
-#         if ctx.node.properties.get('use_external_resource', False):
-#             raise cfy_exc.NonRecoverableError(
-#                 "Can't use non-existing managed_cluster '{0}'.".format(
-#                     cluster_name))
-#         else:
-#             try:
-#                 result = \
-#                     managed_cluster.create_or_update(resource_group,
-#                                                      cluster_name,
-#                                                      resource_config_payload)
-#             except CloudError as cr:
-#                 raise cfy_exc.NonRecoverableError(
-#                     "create managed_cluster '{0}' "
-#                     "failed with this error : {1}".format(cluster_name,
-#                                                           cr.message)
-#                     )
-#
-#     ctx.instance.runtime_properties['resource_group'] = resource_group
-#     ctx.instance.runtime_properties['resource'] = result
-#     ctx.instance.runtime_properties['resource_id'] = result.get("id", "")
-#     ctx.instance.runtime_properties['name'] = cluster_name
-#
-#     if store_kube_config_in_runtime:
-#         ctx.instance.runtime_properties['kubeconf'] = \
-#             yaml.load(base64.b64decode(managed_cluster.get_admin_kubeconf(
-#                 resource_group, cluster_name)))
-
-
 @operation(resumable=True)
 @decorators.with_azure_resource(ManagedCluster)
 def create(ctx, resource_group, cluster_name, resource_config, **_):

--- a/cloudify_azure/resources/compute/managed_cluster.py
+++ b/cloudify_azure/resources/compute/managed_cluster.py
@@ -77,7 +77,7 @@ from azure_sdk.resources.compute.managed_cluster import ManagedCluster
 
 @operation(resumable=True)
 @decorators.with_azure_resource(ManagedCluster)
-def create(ctx, resource_group, cluster_name, resource_config, **kwargs):
+def create(ctx, resource_group, cluster_name, resource_config, **_):
     managed_cluster = get_manged_cluster_interface(ctx)
     resource_config_payload = {}
     resource_config_payload = \
@@ -98,7 +98,7 @@ def create(ctx, resource_group, cluster_name, resource_config, **kwargs):
     utils.save_common_info_in_runtime_properties(resource_group,
                                                  cluster_name,
                                                  result)
-    store_kubeconf_if_needed(ctx, resource_group, cluster_name)
+    # store_kubeconf_if_needed(ctx, resource_group, cluster_name)
 
 
 def get_manged_cluster_interface(ctx):
@@ -109,7 +109,10 @@ def get_manged_cluster_interface(ctx):
     return ManagedCluster(azure_config, ctx.logger, api_version)
 
 
-def store_kubeconf_if_needed(ctx, resource_group, name):
+@operation(resumable=True)
+def store_kubeconf_if_needed(ctx):
+    resource_group = utils.get_resource_group(ctx)
+    name = utils.get_resource_name(ctx)
     managed_cluster = get_manged_cluster_interface(ctx)
     store_kube_config_in_runtime = \
         ctx.node.properties.get('store_kube_config_in_runtime')
@@ -121,7 +124,7 @@ def store_kubeconf_if_needed(ctx, resource_group, name):
 
 
 @operation(resumable=True)
-def delete(ctx, **kwargs):
+def delete(ctx, **_):
     if ctx.node.properties.get('use_external_resource', False):
         return
     resource_group = ctx.instance.runtime_properties.get('resource_group')

--- a/cloudify_azure/resources/compute/managed_cluster.py
+++ b/cloudify_azure/resources/compute/managed_cluster.py
@@ -21,81 +21,112 @@ from msrestazure.azure_exceptions import CloudError
 from cloudify.decorators import operation
 from cloudify import exceptions as cfy_exc
 
-from cloudify_azure import (constants, utils)
+from cloudify_azure import (constants, utils, decorators)
 from azure_sdk.resources.compute.managed_cluster import ManagedCluster
 
 
+# @operation(resumable=True)
+# def create(ctx, resource_group, cluster_name, resource_config, **kwargs):
+#     azure_config = utils.get_client_config(ctx.node.properties)
+#     store_kube_config_in_runtime = \
+#         ctx.node.properties.get('store_kube_config_in_runtime')
+#     api_version = \
+#         ctx.node.properties.get('api_version',
+#                                 constants.API_VER_MANAGED_CLUSTER)
+#     managed_cluster = ManagedCluster(azure_config, ctx.logger, api_version)
+#     resource_config_payload = {}
+#     resource_config_payload = \
+#         utils.handle_resource_config_params(resource_config_payload,
+#                                             resource_config)
+#     try:
+#         result = managed_cluster.get(resource_group, cluster_name)
+#         if ctx.node.properties.get('use_external_resource', False):
+#             ctx.logger.info("Using external resource")
+#         else:
+#             ctx.logger.info("Resource with name {0} exists".format(
+#                 cluster_name))
+#             return
+#     except CloudError:
+#         if ctx.node.properties.get('use_external_resource', False):
+#             raise cfy_exc.NonRecoverableError(
+#                 "Can't use non-existing managed_cluster '{0}'.".format(
+#                     cluster_name))
+#         else:
+#             try:
+#                 result = \
+#                     managed_cluster.create_or_update(resource_group,
+#                                                      cluster_name,
+#                                                      resource_config_payload)
+#             except CloudError as cr:
+#                 raise cfy_exc.NonRecoverableError(
+#                     "create managed_cluster '{0}' "
+#                     "failed with this error : {1}".format(cluster_name,
+#                                                           cr.message)
+#                     )
+#
+#     ctx.instance.runtime_properties['resource_group'] = resource_group
+#     ctx.instance.runtime_properties['resource'] = result
+#     ctx.instance.runtime_properties['resource_id'] = result.get("id", "")
+#     ctx.instance.runtime_properties['name'] = cluster_name
+#
+#     if store_kube_config_in_runtime:
+#         ctx.instance.runtime_properties['kubeconf'] = \
+#             yaml.load(base64.b64decode(managed_cluster.get_admin_kubeconf(
+#                 resource_group, cluster_name)))
+
+
 @operation(resumable=True)
+@decorators.with_azure_resource(ManagedCluster)
 def create(ctx, resource_group, cluster_name, resource_config, **kwargs):
-    azure_config = ctx.node.properties.get('azure_config')
-    if not azure_config.get("subscription_id"):
-        azure_config = ctx.node.properties.get('client_config')
-    else:
-        ctx.logger.warn("azure_config is deprecated please use client_config, "
-                        "in later version it will be removed")
-    store_kube_config_in_runtime = \
-        ctx.node.properties.get('store_kube_config_in_runtime')
-    api_version = \
-        ctx.node.properties.get('api_version',
-                                constants.API_VER_MANAGED_CLUSTER)
-    managed_cluster = ManagedCluster(azure_config, ctx.logger, api_version)
+    managed_cluster = get_manged_cluster_interface(ctx)
     resource_config_payload = {}
     resource_config_payload = \
         utils.handle_resource_config_params(resource_config_payload,
                                             resource_config)
     try:
-        result = managed_cluster.get(resource_group, cluster_name)
-        if ctx.node.properties.get('use_external_resource', False):
-            ctx.logger.info("Using external resource")
-        else:
-            ctx.logger.info("Resource with name {0} exists".format(
-                cluster_name))
-            return
-    except CloudError:
-        if ctx.node.properties.get('use_external_resource', False):
-            raise cfy_exc.NonRecoverableError(
-                "Can't use non-existing managed_cluster '{0}'.".format(
-                    cluster_name))
-        else:
-            try:
-                result = \
-                    managed_cluster.create_or_update(resource_group,
-                                                     cluster_name,
-                                                     resource_config_payload)
-            except CloudError as cr:
-                raise cfy_exc.NonRecoverableError(
-                    "create managed_cluster '{0}' "
-                    "failed with this error : {1}".format(cluster_name,
-                                                          cr.message)
-                    )
+        result = \
+            managed_cluster.create_or_update(resource_group,
+                                             cluster_name,
+                                             resource_config_payload)
+    except CloudError as cr:
+        raise cfy_exc.NonRecoverableError(
+            "create managed_cluster '{0}' "
+            "failed with this error : {1}".format(cluster_name,
+                                                  cr.message)
+            )
 
-    ctx.instance.runtime_properties['resource_group'] = resource_group
-    ctx.instance.runtime_properties['resource'] = result
-    ctx.instance.runtime_properties['resource_id'] = result.get("id", "")
-    ctx.instance.runtime_properties['name'] = cluster_name
+    utils.save_common_info_in_runtime_properties(resource_group,
+                                                 cluster_name,
+                                                 result)
+    store_kubeconf_if_needed(ctx, resource_group, cluster_name)
+
+
+def get_manged_cluster_interface(ctx):
+    azure_config = utils.get_client_config(ctx.node.properties)
+    api_version = \
+        ctx.node.properties.get('api_version',
+                                constants.API_VER_MANAGED_CLUSTER)
+    return ManagedCluster(azure_config, ctx.logger, api_version)
+
+
+def store_kubeconf_if_needed(ctx, resource_group, name):
+    managed_cluster = get_manged_cluster_interface(ctx)
+    store_kube_config_in_runtime = \
+        ctx.node.properties.get('store_kube_config_in_runtime')
 
     if store_kube_config_in_runtime:
         ctx.instance.runtime_properties['kubeconf'] = \
             yaml.load(base64.b64decode(managed_cluster.get_admin_kubeconf(
-                resource_group, cluster_name)))
+                resource_group, name)))
 
 
 @operation(resumable=True)
 def delete(ctx, **kwargs):
     if ctx.node.properties.get('use_external_resource', False):
         return
-    azure_config = ctx.node.properties.get('azure_config')
-    if not azure_config.get("subscription_id"):
-        azure_config = ctx.node.properties.get('client_config')
-    else:
-        ctx.logger.warn("azure_config is deprecated please use client_config, "
-                        "in later version it will be removed")
     resource_group = ctx.instance.runtime_properties.get('resource_group')
     name = ctx.instance.runtime_properties.get('name')
-    api_version = \
-        ctx.node.properties.get('api_version',
-                                constants.API_VER_MANAGED_CLUSTER)
-    managed_cluster = ManagedCluster(azure_config, ctx.logger, api_version)
+    managed_cluster = get_manged_cluster_interface(ctx)
     try:
         managed_cluster.get(resource_group, name)
     except CloudError:

--- a/cloudify_azure/resources/compute/managed_cluster.py
+++ b/cloudify_azure/resources/compute/managed_cluster.py
@@ -25,6 +25,14 @@ from cloudify_azure import (constants, utils, decorators)
 from azure_sdk.resources.compute.managed_cluster import ManagedCluster
 
 
+def get_manged_cluster_interface(ctx):
+    azure_config = utils.get_client_config(ctx.node.properties)
+    api_version = \
+        ctx.node.properties.get('api_version',
+                                constants.API_VER_MANAGED_CLUSTER)
+    return ManagedCluster(azure_config, ctx.logger, api_version)
+
+
 @operation(resumable=True)
 @decorators.with_azure_resource(ManagedCluster)
 def create(ctx, resource_group, cluster_name, resource_config, **_):
@@ -48,15 +56,6 @@ def create(ctx, resource_group, cluster_name, resource_config, **_):
     utils.save_common_info_in_runtime_properties(resource_group,
                                                  cluster_name,
                                                  result)
-    # store_kubeconf_if_needed(ctx, resource_group, cluster_name)
-
-
-def get_manged_cluster_interface(ctx):
-    azure_config = utils.get_client_config(ctx.node.properties)
-    api_version = \
-        ctx.node.properties.get('api_version',
-                                constants.API_VER_MANAGED_CLUSTER)
-    return ManagedCluster(azure_config, ctx.logger, api_version)
 
 
 @operation(resumable=True)

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,9 +5,9 @@
 plugins:
   azure:
     executor: central_deployment_agent
-    source: https://github.com/cloudify-cosmo/cloudify-azure-plugin/archive/3.2.1.zip
+    source: https://github.com/cloudify-cosmo/cloudify-azure-plugin/archive/3.3.0.zip
     package_name: cloudify-azure-plugin
-    package_version: '3.2.1'
+    package_version: '3.3.0'
 
 data_types:
   cloudify.datatypes.azure.Config:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1693,10 +1693,11 @@ node_types:
   cloudify.azure.nodes.compute.ManagedCluster:
     derived_from: cloudify.nodes.Root
     properties:
+      <<: *existing_resources
       resource_group:
         required: true
         type: string
-      cluster_name:
+      name:
         required: true
         type: string
       resource_config:
@@ -1729,7 +1730,7 @@ node_types:
             resource_group:
               default: { get_property: [SELF, resource_group]}
             cluster_name:
-              default: { get_property: [SELF, cluster_name]}
+              default: { get_property: [SELF, name]}
             resource_config:
               default: { get_property: [SELF, resource_config]}
             azure_config:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1737,6 +1737,8 @@ node_types:
               default: { get_property: [SELF, azure_config]}
             client_config:
               default: { get_property: [SELF, client_config]}
+        configure:
+          implementation: azure.cloudify_azure.resources.compute.managed_cluster.store_kubeconf_if_needed
         delete:
           implementation: azure.cloudify_azure.resources.compute.managed_cluster.delete
 


### PR DESCRIPTION
Added create if missing for compute ressources, except container service which is deprecated so I will leave it as is for now. 
for AKS I added configure operation in order to save kubeconfig in runtime property if using external resource.