### PR TITLE
RD-4745-Handle-PyYaml-Load-Deprecation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+3.7.1: Handle PyYaml load function deprecation.
 3.7.0: Azure Managed Identity
 3.6.1: RD-3867 VM None State is Valid in Stop
 3.6.0: RD-1047 Custom Types

--- a/cloudify_azure/resources/compute/managed_cluster.py
+++ b/cloudify_azure/resources/compute/managed_cluster.py
@@ -100,7 +100,7 @@ def _store_kubeconf_if_needed(_ctx):
 
     if store_kube_config_in_runtime:
         _ctx.instance.runtime_properties['kubeconf'] = \
-            yaml.load(base64.b64decode(managed_cluster.get_admin_kubeconf(
+            yaml.safe_load(base64.b64decode(managed_cluster.get_admin_kubeconf(
                 resource_group, name)))
 
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -6,7 +6,7 @@ plugins:
   azure:
     executor: central_deployment_agent
     package_name: cloudify-azure-plugin
-    package_version: '3.7.0'
+    package_version: '3.7.1'
 
 data_types:
   cloudify.datatypes.azure.Config:


### PR DESCRIPTION
given that we updated pyyaml that we use in the plugin (>5.1) , this change is required to handle deprecation 