### PR TITLE
RD-5629-Fix-SecurityRule-Method

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+3.7.8: Fix SecurityRule method deprecation.
 3.7.7: Rerelease with redhat wagon and dsl 1_4 yaml.
 3.7.6: Fix resource tags.
 3.7.5: Release plugin with v2 resource tags.

--- a/azure_sdk/common.py
+++ b/azure_sdk/common.py
@@ -36,8 +36,7 @@ class AzureResource(object):
             self.creds['cloud_environment'] = AZURE_PUBLIC_CLOUD
 
         subscription_id = azure_config.get("subscription_id") or \
-                          azure_config_env_vars.get(
-                              'AZURE_SUBSCRIPTION_ID')
+            azure_config_env_vars.get('AZURE_SUBSCRIPTION_ID')
         self._credentials = None
 
         # Traditional method

--- a/azure_sdk/resources/custom.py
+++ b/azure_sdk/resources/custom.py
@@ -29,7 +29,7 @@ class CustomAzureResource(AzureResource):
         if not custom_resource_module.startswith('azure'):
             raise AzureCustomResourceError(
                 'Only modules from Azure namespace may be imported.'
-        )
+            )
         try:
             self.client_module = import_module(custom_resource_module)
         except ModuleNotFoundError as e:

--- a/azure_sdk/resources/network/network_security_rule.py
+++ b/azure_sdk/resources/network/network_security_rule.py
@@ -48,7 +48,7 @@ class NetworkSecurityRule(AzureResource):
         self.logger.info(
             "Create/Updating network_security_rule...{0}".format(
                 security_rule_name))
-        async_nsr_creation = self.client.security_rules.create_or_update(
+        async_nsr_creation = self.client.security_rules.begin_create_or_update(
             resource_group_name=group_name,
             network_security_group_name=network_security_group_name,
             security_rule_name=security_rule_name,
@@ -66,7 +66,7 @@ class NetworkSecurityRule(AzureResource):
                security_rule_name):
         self.logger.info(
             "Deleting network_security_rule...{0}".format(security_rule_name))
-        delete_async_operation = self.client.security_rules.delete(
+        delete_async_operation = self.client.security_rules.begin_delete(
             resource_group_name=group_name,
             network_security_group_name=network_security_group_name,
             security_rule_name=security_rule_name

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -6,7 +6,7 @@ plugins:
   azure:
     executor: central_deployment_agent
     package_name: cloudify-azure-plugin
-    package_version: '3.7.7'
+    package_version: '3.7.8'
 
 data_types:
   cloudify.datatypes.azure.Config:

--- a/plugin_1_4.yaml
+++ b/plugin_1_4.yaml
@@ -6,7 +6,7 @@ plugins:
   azure:
     executor: central_deployment_agent
     package_name: cloudify-azure-plugin
-    package_version: '3.7.7'
+    package_version: '3.7.8'
 
 data_types:
   cloudify.datatypes.azure.Config:

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ whitelist_externals = bash
 [testenv:linting]
 commands =
     flake8 cloudify_azure
+    flake8 azure_sdk
 
 [testenv:unittesting]
 commands =
@@ -33,4 +34,3 @@ show-source = True
 ignore =
 exclude=.venv,.tox,dist,*egg,etc,build,bin,lib,local,share
 filename=*.py
-

--- a/v2_plugin.yaml
+++ b/v2_plugin.yaml
@@ -6,7 +6,7 @@ plugins:
   azure:
     executor: central_deployment_agent
     package_name: cloudify-azure-plugin
-    package_version: '3.7.7'
+    package_version: '3.7.8'
 
 data_types:
   cloudify.datatypes.azure.Config:


### PR DESCRIPTION
The method that we used in the sdk is invalid with recent azure changes , which cause this exception while trying to create NetworkSecurityRule 
```
async_nsr_creation = self.client.security_rules.create_or_update(
AttributeError: 'SecurityRulesOperations' object has no attribute 'create_or_update'
```

method name is changed to `begin_create_or_update`

same for the delete it is changed to `begin_delete`