### PR TITLE
RD-5641-Handle-Parent-For-External-Resources

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+3.7.9: Add parent resource ids logic when use_external_resource.
 3.7.8: Fix SecurityRule method deprecation.
 3.7.7: Rerelease with redhat wagon and dsl 1_4 yaml.
 3.7.6: Fix resource tags.

--- a/cloudify_azure/decorators.py
+++ b/cloudify_azure/decorators.py
@@ -304,24 +304,24 @@ class ResourceGetter(object):
                 # virtual_machine_extension
             elif isinstance(resource, VirtualMachineExtension):
                 vm_name = self.ctx.node.properties.get('virtual_machine_name')
-                parent = {'virtual_machine': vm_name}
+                parent.update({'virtual_machine': vm_name})
                 exists = resource.get(resource_group_name, vm_name, self.name)
                 # subnet
             elif isinstance(resource, Subnet):
                 vnet_name = utils.get_virtual_network(self.ctx)
-                parent = {'virtual_network': vnet_name}
+                parent.update({'virtual_network': vnet_name})
                 exists = resource.get(resource_group_name, vnet_name,
                                       self.name)
                 # route
             elif isinstance(resource, Route):
                 rtbl_name = utils.get_route_table(self.ctx)
-                parent = {'route_table': rtbl_name}
+                parent.update({'route_table': rtbl_name})
                 exists = resource.get(resource_group_name, rtbl_name,
                                       self.name)
                 # network_security_rule
             elif isinstance(resource, NetworkSecurityRule):
                 nsg_name = utils.get_network_security_group(self.ctx)
-                parent = {'network_security_group': nsg_name}
+                parent.update({'network_security_group': nsg_name})
                 exists = resource.get(resource_group_name, nsg_name, self.name)
                 # load_balancer_backend_address_pool
             elif isinstance(resource, (LoadBalancerBackendAddressPool,
@@ -329,14 +329,14 @@ class ResourceGetter(object):
                                        LoadBalancerInboundNatRule,
                                        LoadBalancerProbe)):
                 lb_name = utils.get_load_balancer(self.ctx)
-                parent = {'load_balancer': lb_name}
+                parent.update({'load_balancer': lb_name})
                 exists = resource.get(resource_group_name,
                                       lb_name,
                                       self.name)
             # file share
             elif isinstance(resource, FileShare):
                 sa_name = utils.get_storage_account(self.ctx)
-                parent = {'storage_account': sa_name}
+                parent.update({'storage_account': sa_name})
                 exists = resource.get(resource_group_name, sa_name, self.name)
             else:
                 exists = resource.get(resource_group_name, self.name)

--- a/cloudify_azure/utils.py
+++ b/cloudify_azure/utils.py
@@ -485,12 +485,16 @@ def check_if_resource_exists(resource, resource_group_name, name=None):
 
 def save_common_info_in_runtime_properties(resource_group_name,
                                            resource_name,
-                                           resource_get_create_result):
+                                           resource_get_create_result,
+                                           parent=None):
     ctx.instance.runtime_properties['resource_group'] = resource_group_name
     ctx.instance.runtime_properties['resource'] = resource_get_create_result
     ctx.instance.runtime_properties['resource_id'] = \
         resource_get_create_result.get("id", "")
     ctx.instance.runtime_properties['name'] = resource_name
+    if parent:
+        for k, v in parent.items():
+            ctx.instance.runtime_properties[k] = v
 
 
 def handle_task(resource,

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -6,7 +6,7 @@ plugins:
   azure:
     executor: central_deployment_agent
     package_name: cloudify-azure-plugin
-    package_version: '3.7.8'
+    package_version: '3.7.9'
 
 data_types:
   cloudify.datatypes.azure.Config:

--- a/plugin_1_4.yaml
+++ b/plugin_1_4.yaml
@@ -6,7 +6,7 @@ plugins:
   azure:
     executor: central_deployment_agent
     package_name: cloudify-azure-plugin
-    package_version: '3.7.8'
+    package_version: '3.7.9'
 
 data_types:
   cloudify.datatypes.azure.Config:

--- a/v2_plugin.yaml
+++ b/v2_plugin.yaml
@@ -6,7 +6,7 @@ plugins:
   azure:
     executor: central_deployment_agent
     package_name: cloudify-azure-plugin
-    package_version: '3.7.8'
+    package_version: '3.7.9'
 
 data_types:
   cloudify.datatypes.azure.Config:


### PR DESCRIPTION
a couple of stuff addressed here , runtime-property of parent based on the resource type and name property to not override with the name of the parent 

this to address missing parent in get while deleting a resource with `use_external_resource:true` 
for example:

```
2022-08-21 14:06:46.025  CFY <network> [private_subnet_2_t92pql.delete] Task failed 'cloudify_azure.resources.network.subnet.delete' -> get() missing 1 required positional argument: 'subnet_name'
Traceback (most recent call last):
....
  File "/opt/mgmtworker/env/plugins/default_tenant/cloudify-azure-plugin/3.7.8/lib/python3.6/site-packages/cloudify_azure/utils.py", line 530, in handle_task
    return task(*args, **kwargs)
TypeError: get() missing 1 required positional argument: 'subnet_name'
```